### PR TITLE
chore: add MIT license and update package metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Yoshifumi Nakahira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-pyodide",
   "version": "1.0.0",
-  "description": "",
+  "description": "Model Context Protocol Server implementation with Pyodide",
   "main": "index.js",
   "type": "module",
   "bin": {
@@ -13,9 +13,14 @@
   "files": [
     "build"
   ],
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "keywords": [
+  "mcp",
+  "model context protocol",
+  "pyodide",
+  "python"
+],
+  "author": "Yoshifumi Nakahira (https://github.com/yonaka15)",
+  "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.4.0",
     "arktype": "^2.0.1",


### PR DESCRIPTION
- Add MIT license file
- Update package description for Model Context Protocol Server
- Add keywords related to MCP and Pyodide
- Add author information
- Change license from ISC to MIT in package.json