### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Pyodide server implementation for the Model Context Protocol (MCP). This server enables Large Language Models (LLMs) to execute Python code through the MCP interface.
 
+<a href="https://glama.ai/mcp/servers/pxls43joly">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/pxls43joly/badge" alt="mcp-pyodide MCP server" />
+</a>
+
 ## Features
 
 - Python code execution capability for LLMs using Pyodide
@@ -138,4 +142,3 @@ ISC
 ## Support
 
 Please use the Issue tracker for problems and questions.
-


### PR DESCRIPTION
This PR adds a badge for the [mcp-pyodide](https://glama.ai/mcp/servers/pxls43joly) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/pxls43joly">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/pxls43joly/badge" alt="mcp-pyodide MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.