### PR TITLE
feat: add support for installing multiple Python packages

### DIFF
--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -22,13 +22,13 @@ export const EXECUTE_PYTHON_TOOL: Tool = {
 
 export const INSTALL_PYTHON_PACKAGES_TOOL: Tool = {
   name: "install-python-packages",
-  description: "Install Python packages using Pyodide",
+  description: "Install Python packages using Pyodide. Multiple packages can be specified using space-separated format.",
   inputSchema: {
     type: "object",
     properties: {
       package: {
         type: "string",
-        description: "Python package to install",
+        description: "Python package(s) to install. For multiple packages, use space-separated format (e.g., 'numpy matplotlib pandas').",
       },
     },
     required: ["package"],


### PR DESCRIPTION
Enable installing multiple Python packages in a single request by accepting space-separated package names in the  parameter. The implementation:

- Splits the package string into individual package names
- Installs each package separately
- Collects success/failure results for each package
- Returns a consolidated output with status for each package

This feature maintains backward compatibility with single package installation while improving efficiency for users installing multiple related packages.