### PR TITLE
feat: Add Volta configuration for Node.js version 23.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "@types/express": "^5.0.0",
     "@types/node": "^22.10.10",
     "typescript": "^5.7.3"
+  },
+  "volta": {
+    "node": "23.10.0"
   }
 }


### PR DESCRIPTION
Add Volta configuration to package.json to pin Node.js version to 23.10.0.