### PR TITLE
fix: standardize tool naming convention from hyphen to underscore

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -84,7 +84,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const pyodideManager = PyodideManager.getInstance();
 
     switch (name) {
-      case "execute-python": {
+      case "pyodide_execute": {
         const executePythonArgs = isExecutePythonArgs(args);
         if (executePythonArgs instanceof type.errors) {
           throw executePythonArgs;
@@ -93,7 +93,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const results = await pyodideManager.executePython(code, timeout);
         return results;
       }
-      case "install-python-packages": {
+      case "pyodide_install-packages": {
         const installPythonPackagesArgs = isInstallPythonPackagesArgs(args);
         if (installPythonPackagesArgs instanceof type.errors) {
           throw installPythonPackagesArgs;
@@ -102,11 +102,11 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const results = await pyodideManager.installPackage(packageName);
         return results;
       }
-      case "get-mount-points": {
+      case "pyodide_get-mount-points": {
         const results = await pyodideManager.getMountPoints();
         return results;
       }
-      case "list-mounted-directory": {
+      case "pyodide_list-mounted-directory": {
         const listMountedDirectoryArgs = isListMountedDirectoryArgs(args);
         if (listMountedDirectoryArgs instanceof type.errors) {
           throw listMountedDirectoryArgs;
@@ -115,7 +115,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const results = await pyodideManager.listMountedDirectory(mountName);
         return results;
       }
-      case "read-image": {
+      case "pyodide_read-image": {
         const readImageArgs = isReadImageArgs(args);
         if (readImageArgs instanceof type.errors) {
           throw readImageArgs;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,7 +1,7 @@
 import { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 export const EXECUTE_PYTHON_TOOL: Tool = {
-  name: "pyodide-execute",
+  name: "pyodide_execute",
   description:
     "Execute Python code using Pyodide with output capture. When generating images, they will be automatically saved to the output directory instead of being displayed. Images can be accessed from the saved file paths that will be included in the output.",
   inputSchema: {
@@ -21,7 +21,7 @@ export const EXECUTE_PYTHON_TOOL: Tool = {
 };
 
 export const INSTALL_PYTHON_PACKAGES_TOOL: Tool = {
-  name: "pyodide-install-packages",
+  name: "pyodide_install-packages",
   description:
     "Install Python packages using Pyodide. Multiple packages can be specified using space-separated format.",
   inputSchema: {
@@ -38,7 +38,7 @@ export const INSTALL_PYTHON_PACKAGES_TOOL: Tool = {
 };
 
 export const GET_MOUNT_POINTS_TOOL: Tool = {
-  name: "pyodide-get-mount-points",
+  name: "pyodide_get-mount-points",
   description: "List mounted directories",
   inputSchema: {
     type: "object",
@@ -47,7 +47,7 @@ export const GET_MOUNT_POINTS_TOOL: Tool = {
 };
 
 export const LIST_MOUNTED_DIRECTORY_TOOL: Tool = {
-  name: "pyodide-list-mounted-directory",
+  name: "pyodide_list-mounted-directory",
   description: "List contents of a mounted directory",
   inputSchema: {
     type: "object",
@@ -62,7 +62,7 @@ export const LIST_MOUNTED_DIRECTORY_TOOL: Tool = {
 };
 
 export const READ_IMAGE_TOOL: Tool = {
-  name: "pyodide-read-image",
+  name: "pyodide_read-image",
   description: "Read an image from a mounted directory",
   inputSchema: {
     type: "object",


### PR DESCRIPTION
This commit changes the tool naming pattern from hyphen-separated to underscore_separated format to ensure consistency between tool definitions and handler implementations. This standardization helps with:

1. Ensuring tool names match across the codebase
2. Maintaining consistency with MCP API naming conventions
3. Preventing potential issues with tool name resolution

The affected tools are:
- execute-python → pyodide_execute
- install-python-packages → pyodide_install-packages
- get-mount-points → pyodide_get-mount-points
- list-mounted-directory → pyodide_list-mounted-directory
- read-image → pyodide_read-image